### PR TITLE
Initial commit, support for list verb, for kinds placementrules & pla…

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -546,24 +546,29 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) erro
 	err := r.Get(context.Background(), types.NamespacedName{Name: ROLENAME, Namespace: namespace}, &rbacv1.Role{})
 	if k8errors.IsNotFound(err) {
 		klog.Infof("creating role %s, in namespace %s", ROLENAME, namespace)
+
 		err = r.Create(context.Background(), getRoleDuck(namespace))
 		if err != nil {
 			return err
 		}
 	}
+
 	err = r.Get(context.Background(), types.NamespacedName{Name: ROLEBINDINGNAME, Namespace: namespace}, &rbacv1.ClusterRoleBinding{})
 	if k8errors.IsNotFound(err) {
 		klog.Infof("creating roleBinding %s, in namespace %s", ROLEBINDINGNAME, namespace)
+
 		err = r.Create(context.Background(), getRoleBindingDuck(namespace))
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
 // GetManagedClusters retrieves managed cluster names from placement decision
 func (r *ReconcileGitOpsCluster) GetManagedClusters(namespace string, placementref v1.ObjectReference) ([]string, error) {
+
 	if placementref.Kind != "Placement" ||
 		placementref.APIVersion != "cluster.open-cluster-management.io/v1alpha1" {
 		return nil, errInvalidPlacementRef

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -293,7 +294,13 @@ func (r *ReconcileGitOpsCluster) reconcileGitOpsCluster(
 	// 1a. Add configMaps to be used by ArgoCD ApplicationSets
 	err := r.CreateApplicationSetConfigMaps(gitOpsCluster.Spec.ArgoServer.ArgoNamespace)
 	if err != nil {
-		klog.Warningf("ConfigMaps were not created: %v", err.Error())
+		klog.Warningf("there was a problem creating the configMaps: %v", err.Error())
+	}
+
+	// 1b. Add roles so applicationset-controller can read placementRules and placementDecisions
+	err = r.CreateApplicationSetRbac(gitOpsCluster.Spec.ArgoServer.ArgoNamespace)
+	if err != nil {
+		klog.Warningf("there was a problem creating the role or binding: %v", err.Error())
 	}
 
 	// 2. Get the list of managed clusters
@@ -466,6 +473,40 @@ func getConfigMapDuck(configMapName string, namespace string, apiVersion string,
 	}
 }
 
+const ROLENAME = "openshift-gitops-applicationset-controller-placement"
+const ROLEBINDINGNAME = ROLENAME
+
+func getRoleDuck(namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: ROLENAME, Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{
+			rbacv1.PolicyRule{
+				APIGroups: []string{"apps.open-cluster-management.io", "cluster.open-cluster-management.io"},
+				Resources: []string{"placementrules", "placementdecisions"},
+				Verbs:     []string{"list"},
+			},
+		},
+	}
+}
+
+func getRoleBindingDuck(namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: ROLEBINDINGNAME, Namespace: namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     ROLENAME,
+		},
+		Subjects: []rbacv1.Subject{
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      "openshift-gitops-applicationset-controller",
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
 // ApplyApplicationSetConfigMaps creates the required configMap to allow ArgoCD ApplicationSet
 // to identify our two forms of placement
 func (r *ReconcileGitOpsCluster) CreateApplicationSetConfigMaps(namespace string) error {
@@ -494,6 +535,30 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetConfigMaps(namespace string
 		}
 	}
 
+	return nil
+}
+
+func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) error {
+	if namespace == "" {
+		return errors.New("no namespace provided")
+	}
+
+	err := r.Get(context.Background(), types.NamespacedName{Name: ROLENAME, Namespace: namespace}, &rbacv1.Role{})
+	if k8errors.IsNotFound(err) {
+		klog.Infof("creating role %s, in namespace %s", ROLENAME, namespace)
+		err = r.Create(context.Background(), getRoleDuck(namespace))
+		if err != nil {
+			return err
+		}
+	}
+	err = r.Get(context.Background(), types.NamespacedName{Name: ROLEBINDINGNAME, Namespace: namespace}, &rbacv1.ClusterRoleBinding{})
+	if k8errors.IsNotFound(err) {
+		klog.Infof("creating roleBinding %s, in namespace %s", ROLEBINDINGNAME, namespace)
+		err = r.Create(context.Background(), getRoleBindingDuck(namespace))
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -538,6 +538,8 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetConfigMaps(namespace string
 	return nil
 }
 
+// CreateApplicationSetRbac sets up required role and roleBinding so that the applicationset-controller
+// can work with placementRules and placementDecisions
 func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) error {
 	if namespace == "" {
 		return errors.New("no namespace provided")
@@ -568,7 +570,6 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) erro
 
 // GetManagedClusters retrieves managed cluster names from placement decision
 func (r *ReconcileGitOpsCluster) GetManagedClusters(namespace string, placementref v1.ObjectReference) ([]string, error) {
-
 	if placementref.Kind != "Placement" ||
 		placementref.APIVersion != "cluster.open-cluster-management.io/v1alpha1" {
 		return nil, errInvalidPlacementRef

--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -480,7 +480,7 @@ func getRoleDuck(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{Name: ROLENAME, Namespace: namespace},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1.PolicyRule{
+			{
 				APIGroups: []string{"apps.open-cluster-management.io", "cluster.open-cluster-management.io"},
 				Resources: []string{"placementrules", "placementdecisions"},
 				Verbs:     []string{"list"},
@@ -498,7 +498,7 @@ func getRoleBindingDuck(namespace string) *rbacv1.RoleBinding {
 			Name:     ROLENAME,
 		},
 		Subjects: []rbacv1.Subject{
-			rbacv1.Subject{
+			{
 				Kind:      "ServiceAccount",
 				Name:      "openshift-gitops-applicationset-controller",
 				Namespace: namespace,

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -16,6 +16,7 @@ package gitopscluster
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	clusterv1alpha1 "github.com/open-cluster-management/api/cluster/v1alpha1"
 	gitopsclusterV1alpha1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -209,6 +211,11 @@ var (
 		Namespace: "argocd1",
 	}
 
+	applicationsetRole = types.NamespacedName{
+		Name:      ROLENAME,
+		Namespace: "argocd1",
+	}
+
 	gitOpsClusterSecret2 = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster1-cluster-secret",
@@ -367,8 +374,9 @@ func TestReconcileCreateSecretInArgo(t *testing.T) {
 	g.Expect(expectedSecretCreated(c, gitOpsClusterSecret1Key)).To(gomega.BeTrue())
 
 	// Test that the ConfigMaps for ApplicationSets were created
-	g.Expect(expectedConfigMapCreated(c, applicationSetConfigMapNew))
-	g.Expect(expectedConfigMapCreated(c, applicationSetConfigMapOld))
+	g.Expect(expectedConfigMapCreated(c, applicationSetConfigMapNew)).To(gomega.BeTrue())
+	g.Expect(expectedConfigMapCreated(c, applicationSetConfigMapOld)).To(gomega.BeTrue())
+	g.Expect(expectedRbacCreated(c, applicationsetRole)).To(gomega.BeTrue())
 }
 
 func TestReconcileNoSecretInInvalidArgoNamespace(t *testing.T) {
@@ -562,6 +570,31 @@ func expectedConfigMapCreated(c client.Client, expectedConfigMap types.Namespace
 
 		if err == nil {
 			return true
+		}
+
+		if timeout > 30 {
+			return false
+		}
+
+		time.Sleep(time.Second * 3)
+
+		timeout += 3
+	}
+}
+
+func expectedRbacCreated(c client.Client, expectedDetails types.NamespacedName) bool {
+	timeout := 0
+	for {
+		role := &rbacv1.Role{}
+		err := c.Get(context.TODO(), expectedDetails, role)
+		fmt.Printf("role: %v", role)
+		if err == nil {
+			roleBinding := &rbacv1.RoleBinding{}
+			err = c.Get(context.TODO(), expectedDetails, roleBinding)
+
+			if err == nil {
+				return true
+			}
 		}
 
 		if timeout > 30 {

--- a/pkg/controller/gitopscluster/gitopscluster_controller_test.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller_test.go
@@ -584,10 +584,12 @@ func expectedConfigMapCreated(c client.Client, expectedConfigMap types.Namespace
 
 func expectedRbacCreated(c client.Client, expectedDetails types.NamespacedName) bool {
 	timeout := 0
+
 	for {
 		role := &rbacv1.Role{}
 		err := c.Get(context.TODO(), expectedDetails, role)
 		fmt.Printf("role: %v", role)
+
 		if err == nil {
 			roleBinding := &rbacv1.RoleBinding{}
 			err = c.Get(context.TODO(), expectedDetails, roleBinding)


### PR DESCRIPTION
…cementdecisions

Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Add role for placement for use by the applicationset controller service account
* Add rolebinding for new role
* Add test to make sure the role and rolebinding are created

@rokej do you think doing this work on each reconcile, is to expensive, since it should only occur the first time under normal circumstances... It will fix itself is someone deletes the either the role, binding or configmaps....?