### PR TITLE
remove token log

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -70,7 +70,6 @@ var migrationDone = true
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	authCfg := mgr.GetConfig()
-	klog.Infof("Host: %v, BearerToken: %v", authCfg.Host, authCfg.BearerToken)
 	kubeClient := kubernetes.NewForConfigOrDie(authCfg)
 
 	dsRS := &ReconcileGitOpsCluster{


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

remove kubeconfig token from logs