### PR TITLE
remove a condition to ignore placement rule if it contains finalizers

### DIFF
--- a/pkg/controller/placementrule/placementrule_controller.go
+++ b/pkg/controller/placementrule/placementrule_controller.go
@@ -191,10 +191,6 @@ func (r *ReconcilePlacementRule) Reconcile(ctx context.Context, request reconcil
 	for _, cl := range instance.Status.Decisions {
 		orgclmap[cl.ClusterName] = cl.ClusterNamespace
 	}
-	// do nothing if has finalizer
-	if len(instance.GetObjectMeta().GetFinalizers()) != 0 {
-		return reconcile.Result{}, nil
-	}
 
 	// do nothing if not using mcm as scheduler (user set it to something else)
 	scname := instance.Spec.SchedulerName


### PR DESCRIPTION
when defining a finalizer on a placement rule (which I think is totally valid) the placement rule is ignored by the controller.
I consulted with @mikeshng and he agreed that this is probably just a legacy placeholder code that should be removed.
we also asked @rokej who didn't have a good explanation why should the placement rule controller ignore CRs if they contain finalizers.

as part of our work with ACM far edge squad on multi cluster management at scale, we're making extensive use of policies and placement rules while defining finalizers and this bug is blocking us.

would appreciate if this PR can be handled asap. 